### PR TITLE
fix: add more yums to support kudu query

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ADD cloudera-cdh5.repo /etc/yum.repos.d/
 RUN rpm --import http://archive.cloudera.com/beta/impala-kudu/redhat/7/x86_64/impala-kudu/RPM-GPG-KEY-cloudera   
 RUN yum install -y hadoop-libhdfs
 RUN yum install -y impala-kudu impala-kudu-server impala-kudu-shell impala-kudu-catalog impala-kudu-state-store
+RUN yum install -y gcc python-devel cyrus-sasl*
 RUN yum clean all
 
 ADD etc/supervisord.conf /etc/


### PR DESCRIPTION
Problem:
Encounter "Unable to create Kudu client: Invalid argument: Could not connect to the cluster: Client connection negotiation failed: client connection to 172.16.8.64:7051: unable to find SASL plugin: PLAIN" when running kudu queries.

Solution:
Execute "yum install -y gcc python-devel cyrus-sasl*" and restart impala server.